### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,23 @@ These parameters are defined and used in Javascript
 
 ### Video List
 
-You need to modify the yaml front matter in `user\config\video.yaml` to modify the video list.
+The video list is where both the Dynamic Video Player and Video Language Player get their video IDs from.
+You need to modify the yaml config file `user\config\video.yaml` to modify or add a video list.
 
 It will look something like: 
 ``` YAML
-videos: 
+[name_of_video_list]: 
   - name: [name_to_display_here]
+    title:
+        en: [English_video_name]
+        es: [Spanish_video_name]
     ids: 
       - id: [id_for_video]
         language: [code_of_language_to_list_the_video_as]
 ```
+
+The title option is only needed for the Dynamic Video Player.
+
 _Note: you can add as many elements to ids as you like as long as the language is in the language list (see below) and the id  is a valid Vimeo id._
 
 ### Language List
@@ -84,7 +91,7 @@ This list should have a language code for each language you plan to support (the
 
 ### URL Parameters
 
-The URL Parameters are defined in `user\themes\quark\templates\videos.html.twig` in a script tag.
+The URL Parameters are defined in `user\themes\quark\templates\` in a script tag in any of the custom templates (videos.html.twig, video.html.twig, and subtitles.html.twig).
 
 The list should look something like this:
 ``` JSON
@@ -102,9 +109,9 @@ This list must be modified in Vimeo.
 
 ### Visible Options
 
-When editing any of the custom template files (videos.html.twig, video.html.twig, subtitles.html.twig, or any template that extends videos.html.twig), there are 5 blocks to note.
+When editing any of the custom template files (videos.html.twig, video.html.twig, subtitles.html.twig, or any template that extends videos.html.twig), there are 6 blocks to note.
 
-1. The **videoSelect** block which allows the user to select from the video list defined in `user\config\video.yaml`.
+1. The **videoSelect** block which allows the user to select from a video list defined in `user\config\video.yaml`.
 
 2. The **languageSelect** block which allows the user to select a language from the language list defined in `user\config\video.yaml`.
 
@@ -113,6 +120,8 @@ When editing any of the custom template files (videos.html.twig, video.html.twig
 4. The **inlineScript** block which allows for slight variations in the setup for the player via the YAML front matter and initial url parameter reading.
 
 5. The **javascriptFunctions** block which deals directly with all the functions that are defined differently for each video player.
+
+6. The **videoOptions** block which allows the user to navigate forward and backwards between videos with ease.
 
 If you would like to remove any of these blocks from a template that extends videos.html.twig, just add the following to the your custom template:
 ```Twig
@@ -129,11 +138,13 @@ In order to modify any of these blocks, add the following to your template:
 
 ## Types
 
-There are three different types of video player templates setup in this repository.
+There are three different types of video player templates setup in this repository. Each player requires that in the YAML front matter of the page there is an option called `pageIdentifier` which is used to enhance the user experience. 
 
 1. Dynamic Video Player
 
 This video player allows the user to select a video from the video list defined in and a language from the languages list which are both defined in `user\config\video.yaml` as well as a subtilte from a list of subtitles which is loaded with the video.
+
+This option requires that in the YAML front matter of the page there is an option called `videoList`. videoList corresponds to the name of one of the video lists defined in `user\config\video.yaml`.
 
 In order to use this template, make sure the Markdown files is called `videos.*.*md` or `videos.md`.
 
@@ -141,7 +152,7 @@ In order to use this template, make sure the Markdown files is called `videos.*.
 
 This video player allows the user to select a language from the languages list which is defined in `user\config\video.yaml` as well as a subtilte from a list of subtitles which is loaded with the video.
 
-This option requires that in the YAML front matter of the page there is an option called `videoTitle`. videoTitle corresponds to the name of one of the video names listed in the video list in `user\config\video.yaml`.
+This option requires that in the YAML front matter of the page there are options called `videoTitle` and `videoList`. videoTitle corresponds to the name of one of the video names listed in the video list specified by the `videoList` option which corresponds with a video list in `user\config\video.yaml`.
 
 In order to use this template, make sure the Markdown files is called `video.*.*md` or `video.md`.
 
@@ -149,7 +160,7 @@ In order to use this template, make sure the Markdown files is called `video.*.*
 
 This video player allows the user to select a subtilte from a list of subtitles which is loaded with the video.
 
-This option requires that in the YAML front matter of the page there is an option called `videoTitle` and `videoLanguage`. videoTitle corresponds with the name of one of the video names listed in the video list. videoLanguage corresponds with the name of one of the languages listed in the language list. Both of this lists can be found in `user\config\video.yaml`.
+This option requires that in the YAML front matter of the page there is an option called `videoID`. videoID should be a valid Vimeo ID for the video to load.
 
 In order to use this template, make sure the Markdown files is called `subtitles.*.*md` or `subtitles.md`.
 

--- a/user/config/video.yaml
+++ b/user/config/video.yaml
@@ -88,7 +88,7 @@ languages:
   es:
     - name: Inglés
       code: en
-    - name: esañol
+    - name: Español
       code: es
     - name: Kaqchikel
       code: cak

--- a/user/pages/01.videos/videos.en.md
+++ b/user/pages/01.videos/videos.en.md
@@ -2,4 +2,5 @@
 title: Videos
 
 videoList: videos
+pageIdentifier: videos
 ---

--- a/user/pages/01.videos/videos.en.md
+++ b/user/pages/01.videos/videos.en.md
@@ -1,3 +1,5 @@
 ---
 title: Videos
+
+videoList: videos
 ---

--- a/user/pages/01.videos/videos.es.md
+++ b/user/pages/01.videos/videos.es.md
@@ -2,4 +2,5 @@
 title: Videos
 
 videoList: videos
+pageIdentifier: videos
 ---

--- a/user/pages/01.videos/videos.es.md
+++ b/user/pages/01.videos/videos.es.md
@@ -1,3 +1,5 @@
 ---
 title: Videos
+
+videoList: videos
 ---

--- a/user/pages/02.video/video.en.md
+++ b/user/pages/02.video/video.en.md
@@ -2,4 +2,5 @@
 title: Video
 
 videoTitle: Ep. 4
+videoList: videos
 ---

--- a/user/pages/02.video/video.en.md
+++ b/user/pages/02.video/video.en.md
@@ -3,4 +3,5 @@ title: Video
 
 videoTitle: Ep. 4
 videoList: videos
+pageIdentifier: video
 ---

--- a/user/pages/02.video/video.es.md
+++ b/user/pages/02.video/video.es.md
@@ -2,4 +2,5 @@
 title: Video
 
 videoTitle: Ep. 4
+videoList: videos
 ---

--- a/user/pages/02.video/video.es.md
+++ b/user/pages/02.video/video.es.md
@@ -3,4 +3,5 @@ title: Video
 
 videoTitle: Ep. 4
 videoList: videos
+pageIdentifier: video
 ---

--- a/user/pages/03.subtitles/subtitles.en.md
+++ b/user/pages/03.subtitles/subtitles.en.md
@@ -2,4 +2,5 @@
 title: Subtitle
 
 videoID: 27726252
+pageIdentifier: sub
 ---

--- a/user/pages/03.subtitles/subtitles.en.md
+++ b/user/pages/03.subtitles/subtitles.en.md
@@ -1,6 +1,5 @@
 ---
 title: Subtitle
 
-videoTitle: Ep. 4
-videoLanguage: es
+videoID: 27726252
 ---

--- a/user/pages/03.subtitles/subtitles.es.md
+++ b/user/pages/03.subtitles/subtitles.es.md
@@ -2,4 +2,5 @@
 title: Subtitulo
 
 videoID: 27726252
+pageIdentifier: sub
 ---

--- a/user/pages/03.subtitles/subtitles.es.md
+++ b/user/pages/03.subtitles/subtitles.es.md
@@ -1,6 +1,5 @@
 ---
 title: Subtitulo
 
-videoTitle: Ep. 4
-videoLanguage: es
+videoID: 27726252
 ---

--- a/user/pages/assets/js/base.js
+++ b/user/pages/assets/js/base.js
@@ -9,7 +9,7 @@
  * @returns a string which is the url to use as a link to that language for 
  * this page.
  */
-Window.Vinya.fixURLForLanguage = function fixURLForLanguage(lang) {
+Window.Vinya.functions.fixURLForLanguage = function fixURLForLanguage(lang) {
   var url = window.location.href, endpoint = url.substring(url.lastIndexOf('/'));
   url = url.substring(0, url.lastIndexOf('/'));
   url = url.substring(0, url.lastIndexOf('/'));
@@ -21,49 +21,47 @@ Window.Vinya.fixURLForLanguage = function fixURLForLanguage(lang) {
  * Checks to see if the URL contains any parameters.
  * @returns whether or not the url has any url parameters in it.
  */
-Window.Vinya.URLContainsParam = function URLContainsParam() {
-  var paramExists = false;
-  Object.keys(Window.Vinya.URLParams).forEach(function (key) {
+Window.Vinya.functions.URLContainsParam = function URLContainsParam() {
+  for (key in Window.Vinya.URLParams) {
     if (Window.Vinya.url.searchParams.has(Window.Vinya.URLParams[key])) {
-      paramExists = true;
+      return true;
     }
-  });
-  return paramExists;
+  }
+  return false;
 }
 
 /**
  * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
  * @param {String} videoID is the id of the desired video.
  */
-Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoID) {
+Window.Vinya.functions.createVimeoPlayer = function createVimeoPlayer(videoID) {
   // create iframe
-  console.log(videoID);
   Window.Vinya.videoOptions.id = videoID;
   Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
-  Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
+  Window.Vinya.player.on("timeupdate", Window.Vinya.functions.updateURLTime); // updates the url time when progress is made in the video
   Window.Vinya.player.on("texttrackchange", function (lang) {
     if (!lang.language) {
       // remove the sub from the url
       Window.Vinya.DOMElements.subtitles.value = 'off';
-      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.sub, 'off');
     } else {
       Window.Vinya.DOMElements.subtitles.value = lang.language;
-      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.sub, lang.language);
     }
   });
   Window.Vinya.player.on("loaded", function () {
     Window.Vinya.DOMElements.video = document.querySelector('iframe');
     Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
-    Window.Vinya.getTextTracks();         
+    Window.Vinya.functions.getTextTracks();         
   });
 }
 
 /**
  * updates the time in the url.
  */
-Window.Vinya.updateURLTime = function updateURLTime() {
+Window.Vinya.functions.updateURLTime = function updateURLTime() {
   Window.Vinya.player.getCurrentTime().then(function(seconds) {
-    Window.Vinya.updateURL(Window.Vinya.URLParams.time, seconds);
+    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.time, seconds);
   });
 }
 
@@ -72,7 +70,7 @@ Window.Vinya.updateURLTime = function updateURLTime() {
  * select for subtitles. It also selects the subtitle value listed in url 
  * parameter if it exists. 
  */
-Window.Vinya.getTextTracks = function getTextTracks() {
+Window.Vinya.functions.getTextTracks = function getTextTracks() {
   // remove all added tracks
   var elements = document.querySelectorAll('.added');
   for (var i = 0, length =  elements.length; i < length; i++) {
@@ -99,7 +97,7 @@ Window.Vinya.getTextTracks = function getTextTracks() {
         Window.Vinya.DOMElements.subtitles.value = Window.Vinya.url.searchParams.get(Window.Vinya.URLParams.sub);
       } else if (trackSelected) {
         Window.Vinya.DOMElements.subtitles.value = lang;
-        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang);
+        Window.Vinya.functions.updateURL(Window.Vinya.URLParams.sub, lang);
       }
     }
     Window.Vinya.DOMElements.hide('spinner');

--- a/user/pages/assets/js/base.js
+++ b/user/pages/assets/js/base.js
@@ -33,31 +33,29 @@ Window.Vinya.URLContainsParam = function URLContainsParam() {
 
 /**
  * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
- * @param {String} videoName is the name of the video to select.
- * @param {String} videoLanguage is the language to get the video in.
+ * @param {String} videoID is the id of the desired video.
  */
-Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoName, videoLanguage) {
-  if (Window.Vinya.videoPlayerPreCheck(videoName)) {
-    // create iframe
-    Window.Vinya.videoOptions.id = Window.Vinya[videoName][videoLanguage];
-    Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
-    Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
-    Window.Vinya.player.on("texttrackchange", function (lang) {
-      if (!lang.language) {
-        // remove the sub from the url
-        Window.Vinya.DOMElements.subtitles.value = 'off';
-        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
-      } else {
-        Window.Vinya.DOMElements.subtitles.value = lang.language;
-        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
-      }
-    });
-    Window.Vinya.player.on("loaded", function () {
-      Window.Vinya.DOMElements.video = document.querySelector('iframe');
-      Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
-      Window.Vinya.getTextTracks();         
-    });
-  }
+Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoID) {
+  // create iframe
+  console.log(videoID);
+  Window.Vinya.videoOptions.id = videoID;
+  Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
+  Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
+  Window.Vinya.player.on("texttrackchange", function (lang) {
+    if (!lang.language) {
+      // remove the sub from the url
+      Window.Vinya.DOMElements.subtitles.value = 'off';
+      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
+    } else {
+      Window.Vinya.DOMElements.subtitles.value = lang.language;
+      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
+    }
+  });
+  Window.Vinya.player.on("loaded", function () {
+    Window.Vinya.DOMElements.video = document.querySelector('iframe');
+    Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
+    Window.Vinya.getTextTracks();         
+  });
 }
 
 /**

--- a/user/pages/assets/js/base.js
+++ b/user/pages/assets/js/base.js
@@ -31,6 +31,15 @@ Window.Vinya.functions.URLContainsParam = function URLContainsParam() {
 }
 
 /**
+ * updates the time in the url.
+ */
+Window.Vinya.functions.updateURLTime = function updateURLTime() {
+  Window.Vinya.player.getCurrentTime().then(function(seconds) {
+    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.time, seconds);
+  });
+}
+
+/**
  * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
  * @param {String} videoID is the id of the desired video.
  */
@@ -57,15 +66,6 @@ Window.Vinya.functions.createVimeoPlayer = function createVimeoPlayer(videoID) {
 }
 
 /**
- * updates the time in the url.
- */
-Window.Vinya.functions.updateURLTime = function updateURLTime() {
-  Window.Vinya.player.getCurrentTime().then(function(seconds) {
-    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.time, seconds);
-  });
-}
-
-  /**
  * Gets the subtitles and captions for the video and then adds them to the
  * select for subtitles. It also selects the subtitle value listed in url 
  * parameter if it exists. 

--- a/user/pages/assets/js/main.js
+++ b/user/pages/assets/js/main.js
@@ -39,17 +39,17 @@ document.addEventListener("DOMContentLoaded", function(){
   Window.Vinya.url = new URL(window.location.href);
 
   // preprocess check 
-  if (Window.Vinya.URLContainsParam()) {
+  if (Window.Vinya.functions.URLContainsParam()) {
     // update the video accordingly based on the parameters
-    Window.Vinya.parseURL();
+    Window.Vinya.functions.parseURL();
   } else {
-    Window.Vinya.displaySelectedVideo();
+    Window.Vinya.functions.displaySelectedVideo();
   }
   // add the event listeners for the page
-  Window.Vinya.addEventListeners();
+  Window.Vinya.functions.addEventListeners();
 
   // add appropriate url for the language
   for (var i = 0, length = Window.Vinya.DOMElements.langBtns.length; i < length; i++) {
-    Window.Vinya.DOMElements.langBtns[i].setAttribute("href", Window.Vinya.fixURLForLanguage(Window.Vinya.DOMElements.langBtns[i].id));
+    Window.Vinya.DOMElements.langBtns[i].setAttribute("href", Window.Vinya.functions.fixURLForLanguage(Window.Vinya.DOMElements.langBtns[i].id));
   }
 });

--- a/user/pages/assets/js/subtitles.js
+++ b/user/pages/assets/js/subtitles.js
@@ -2,7 +2,7 @@
 /**
  * Adds event listeners for each of the select options.
  */
-Window.Vinya.addEventListeners = function addEventListeners() {
+Window.Vinya.functions.addEventListeners = function addEventListeners() {
   Window.Vinya.DOMElements.subtitles.addEventListener("change", function() {
     if (Window.Vinya.DOMElements.subtitles.value == 'off') {
       Window.Vinya.player.disableTextTrack();
@@ -15,8 +15,8 @@ Window.Vinya.addEventListeners = function addEventListeners() {
 /**
  * Displays the video selected by the user.
  */
-Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoID);
+Window.Vinya.functions.displaySelectedVideo = function displaySelectedVideo() {
+  Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoID);
 }
 
 /**
@@ -24,8 +24,7 @@ Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
  * @param {String} param is the param that will added or updated with the val;
  * @param {*} val is the value to put in the url.
  */
-Window.Vinya.updateURL = function updateURL(param, val) {
-  console.log(param + ':' + val);
+Window.Vinya.functions.updateURL = function updateURL(param, val) {
   if (Window.Vinya.url.searchParams.has(param)) {
     Window.Vinya.url.searchParams.set(param, val);
   } else {
@@ -39,17 +38,17 @@ Window.Vinya.updateURL = function updateURL(param, val) {
   if (history.pushState) {
     window.history.pushState({path:Window.Vinya.url.href},'',Window.Vinya.url.href);
   }
-  Window.Vinya.updateStorage();
+  Window.Vinya.functions.updateStorage();
 }
 
 /**
  * Determines which if any of the videos are in the URL and displays
  * content appropriately.
  */
-Window.Vinya.parseURL = function parseURL() {
+Window.Vinya.functions.parseURL = function parseURL() {
   var params = Window.Vinya.url.searchParams;
   var time = params.get(Window.Vinya.URLParams.time), sub = params.get(Window.Vinya.URLParams.sub);
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoID);
+  Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoID);
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
     Window.Vinya.player.setCurrentTime(time);
@@ -62,7 +61,7 @@ Window.Vinya.parseURL = function parseURL() {
 /**
  * Updates the url parameters in storage by removing all unnecesary url params. 
  */
-Window.Vinya.updateStorage = function updateStorage() {
+Window.Vinya.functions.updateStorage = function updateStorage() {
   // a list of parameters to store in local storage
   var tempURL = new URL(Window.Vinya.url.href.substring(0, Window.Vinya.url.href.indexOf('?')));
   if (Window.Vinya.url.searchParams.has(Window.Vinya.URLParams.sub)) {

--- a/user/pages/assets/js/subtitles.js
+++ b/user/pages/assets/js/subtitles.js
@@ -68,5 +68,5 @@ Window.Vinya.functions.updateStorage = function updateStorage() {
     tempURL.searchParams.append(Window.Vinya.URLParams.sub,Window.Vinya.url.searchParams.get(Window.Vinya.URLParams.sub));
   }
   // store the parameters and current url base
-  localStorage.setItem('subParams', tempURL.search);
+  localStorage.setItem(Window.Vinya.localKey, tempURL.search);
 }

--- a/user/pages/assets/js/subtitles.js
+++ b/user/pages/assets/js/subtitles.js
@@ -16,8 +16,7 @@ Window.Vinya.addEventListeners = function addEventListeners() {
  * Displays the video selected by the user.
  */
 Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
-  // display the selected video
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoLanguage);
+  Window.Vinya.createVimeoPlayer(Window.Vinya.videoID);
 }
 
 /**
@@ -50,7 +49,7 @@ Window.Vinya.updateURL = function updateURL(param, val) {
 Window.Vinya.parseURL = function parseURL() {
   var params = Window.Vinya.url.searchParams;
   var time = params.get(Window.Vinya.URLParams.time), sub = params.get(Window.Vinya.URLParams.sub);
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoLanguage);
+  Window.Vinya.createVimeoPlayer(Window.Vinya.videoID);
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
     Window.Vinya.player.setCurrentTime(time);
@@ -71,30 +70,4 @@ Window.Vinya.updateStorage = function updateStorage() {
   }
   // store the parameters and current url base
   localStorage.setItem('subParams', tempURL.search);
-}
-
-/**
- * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
- * @param {String} videoLanguage is the language to get the video in.
- */
-Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoLanguage) {
-  // create iframe
-  Window.Vinya.videoOptions.id = Window.Vinya.videoID;
-  Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
-  Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
-  Window.Vinya.player.on("texttrackchange", function (lang) {
-    if (!lang.language) {
-      // remove the sub from the url
-      Window.Vinya.DOMElements.subtitles.value = 'off';
-      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
-    } else {
-      Window.Vinya.DOMElements.subtitles.value = lang.language;
-      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
-    }
-  });
-  Window.Vinya.player.on("loaded", function () {
-    Window.Vinya.DOMElements.video = document.querySelector('iframe');
-    Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
-    Window.Vinya.getTextTracks();         
-  });
 }

--- a/user/pages/assets/js/subtitles.js
+++ b/user/pages/assets/js/subtitles.js
@@ -17,7 +17,7 @@ Window.Vinya.addEventListeners = function addEventListeners() {
  */
 Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
   // display the selected video
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoTitle, Window.Vinya.videoLanguage);
+  Window.Vinya.createVimeoPlayer(Window.Vinya.videoLanguage);
 }
 
 /**
@@ -50,7 +50,7 @@ Window.Vinya.updateURL = function updateURL(param, val) {
 Window.Vinya.parseURL = function parseURL() {
   var params = Window.Vinya.url.searchParams;
   var time = params.get(Window.Vinya.URLParams.time), sub = params.get(Window.Vinya.URLParams.sub);
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoTitle, Window.Vinya.videoLanguage);
+  Window.Vinya.createVimeoPlayer(Window.Vinya.videoLanguage);
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
     Window.Vinya.player.setCurrentTime(time);
@@ -74,18 +74,27 @@ Window.Vinya.updateStorage = function updateStorage() {
 }
 
 /**
- * Determines if it is possible to load the desired video and displays
- * the appropriate response if it is not possible.
- * @returns whether or not the desired video is in the current video list.
+ * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
+ * @param {String} videoLanguage is the language to get the video in.
  */
-Window.Vinya.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
-  if (Window.Vinya[videoName][Window.Vinya.videoLanguage] === undefined) {
-    Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
-    if (Window.Vinya.DOMElements.video != undefined) {
-      Window.Vinya.DOMElements.hide('video');
+Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoLanguage) {
+  // create iframe
+  Window.Vinya.videoOptions.id = Window.Vinya.videoID;
+  Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
+  Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
+  Window.Vinya.player.on("texttrackchange", function (lang) {
+    if (!lang.language) {
+      // remove the sub from the url
+      Window.Vinya.DOMElements.subtitles.value = 'off';
+      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
+    } else {
+      Window.Vinya.DOMElements.subtitles.value = lang.language;
+      Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
     }
-    Window.Vinya.DOMElements.hide('spinner');
-    return false;
-  }
-  return true;
+  });
+  Window.Vinya.player.on("loaded", function () {
+    Window.Vinya.DOMElements.video = document.querySelector('iframe');
+    Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
+    Window.Vinya.getTextTracks();         
+  });
 }

--- a/user/pages/assets/js/video.js
+++ b/user/pages/assets/js/video.js
@@ -2,9 +2,9 @@
 /**
  * Adds event listeners for each of the select options.
  */
-Window.Vinya.addEventListeners = function addEventListeners() {
+Window.Vinya.functions.addEventListeners = function addEventListeners() {
   Window.Vinya.DOMElements.languages.addEventListener("change", function() {
-    Window.Vinya.changeVideo(Window.Vinya.videoTitle, true);
+    Window.Vinya.functions.changeVideo(Window.Vinya.videoTitle, true);
   });
 
   Window.Vinya.DOMElements.subtitles.addEventListener("change", function() {
@@ -19,12 +19,12 @@ Window.Vinya.addEventListeners = function addEventListeners() {
 /**
  * Displays the video selected by the user.
  */
-Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
+Window.Vinya.functions.displaySelectedVideo = function displaySelectedVideo() {
   // display the selected video
   var title = Window.Vinya.DOMElements.videoList.value, lang = Window.Vinya.DOMElements.languages.value;
-  if (Window.Vinya.videoPlayerPreCheck(title)) {
-    Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
-    Window.Vinya.updateURL(Window.Vinya.URLParams.lang, lang);
+  if (Window.Vinya.functions.videoPlayerPreCheck(title)) {
+    Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoList[title][lang]);
+    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.lang, lang);
   }
  
 }
@@ -35,13 +35,13 @@ Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
  * @param {String} videoName is the name of the video to display.
  * @param {Boolean} languageChanged is whether or not the language was changed.
  */
-Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
-  if (Window.Vinya.videoPlayerPreCheck(videoName)) {
+Window.Vinya.functions.changeVideo = function changeVideo(videoName, languageChanged) {
+  if (Window.Vinya.functions.videoPlayerPreCheck(videoName)) {
     Window.Vinya.DOMElements.videoError.innerText = ""; 
-    Window.Vinya.updateURL(Window.Vinya.URLParams.lang, Window.Vinya.DOMElements.languages.value);
+    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.lang, Window.Vinya.DOMElements.languages.value);
     Window.Vinya.DOMElements.display('spinner');
     Window.Vinya.player.unload().then(function () {
-      Window.Vinya.videoOptions.id = Window.Vinya[videoName][Window.Vinya.DOMElements.languages.value];
+      Window.Vinya.videoOptions.id = Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value];
       Window.Vinya.player.loadVideo(Window.Vinya.videoOptions).then( function () {
         Window.Vinya.player.ready().then(function(){
           if (languageChanged && Window.Vinya.url.searchParams.has(Window.Vinya.URLParams.time)) {
@@ -54,7 +54,7 @@ Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
       });
     });
     if (!languageChanged) {
-      Window.Vinya.updateURL(Window.Vinya.URLParams.title, videoName);
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.title, videoName);
     }
   }
 }
@@ -64,7 +64,7 @@ Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
  * @param {String} param is the param that will added or updated with the val;
  * @param {*} val is the value to put in the url.
  */
-Window.Vinya.updateURL = function updateURL(param, val) {
+Window.Vinya.functions.updateURL = function updateURL(param, val) {
   if (Window.Vinya.url.searchParams.has(param)) {
     Window.Vinya.url.searchParams.set(param, val);
   } else {
@@ -78,14 +78,14 @@ Window.Vinya.updateURL = function updateURL(param, val) {
   if (history.pushState) {
     window.history.pushState({path:Window.Vinya.url.href},'',Window.Vinya.url.href);
   }
-  Window.Vinya.updateStorage();
+  Window.Vinya.functions.updateStorage();
 }
 
 /**
  * Determines which if any of the videos are in the URL and displays
  * content appropriately.
  */
-Window.Vinya.parseURL = function parseURL() {
+Window.Vinya.functions.parseURL = function parseURL() {
   var params = Window.Vinya.url.searchParams;
   var lang = params.get(Window.Vinya.URLParams.lang), time = params.get(Window.Vinya.URLParams.time),
     sub = params.get(Window.Vinya.URLParams.sub);
@@ -93,8 +93,8 @@ Window.Vinya.parseURL = function parseURL() {
   if (params.has(Window.Vinya.URLParams.lang)) {
     Window.Vinya.DOMElements.languages.value = lang;
   }
-  if (Window.Vinya.videoPlayerPreCheck(title)) {
-    Window.Vinya.createVimeoPlayer(Window.Vinya[Window.Vinya.videoTitle][lang]);
+  if (Window.Vinya.functions.videoPlayerPreCheck(Window.Vinya.videoTitle)) {
+    Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoList[Window.Vinya.videoTitle][lang]);
   }
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
@@ -108,7 +108,7 @@ Window.Vinya.parseURL = function parseURL() {
 /**
  * Updates the url parameters in storage by removing all unnecesary url params. 
  */
-Window.Vinya.updateStorage = function updateStorage() {
+Window.Vinya.functions.updateStorage = function updateStorage() {
   // a list of parameters to store in local storage
   var tempURL = new URL(Window.Vinya.url.href.substring(0, Window.Vinya.url.href.indexOf('?')));
   if (Window.Vinya.url.searchParams.has(Window.Vinya.URLParams.sub)) {
@@ -126,8 +126,8 @@ Window.Vinya.updateStorage = function updateStorage() {
  * the appropriate response if it is not possible.
  * @returns whether or not the desired video is in the current video list.
  */
-Window.Vinya.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
-  if (Window.Vinya[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
+Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
+  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
     Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
     if (Window.Vinya.DOMElements.video != undefined) {
       Window.Vinya.DOMElements.hide('video');

--- a/user/pages/assets/js/video.js
+++ b/user/pages/assets/js/video.js
@@ -60,6 +60,23 @@ Window.Vinya.functions.changeVideo = function changeVideo(videoName, languageCha
 }
 
 /**
+ * Determines if it is possible to load the desired video and displays
+ * the appropriate response if it is not possible.
+ * @returns whether or not the desired video is in the current video list.
+ */
+Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
+  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
+    Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
+    if (Window.Vinya.DOMElements.video != undefined) {
+      Window.Vinya.DOMElements.hide('video');
+    }
+    Window.Vinya.DOMElements.hide('spinner');
+    return false;
+  }
+  return true;
+}
+
+/**
  * Takes a param name and a value and stores that value as the value of the url param.
  * @param {String} param is the param that will added or updated with the val;
  * @param {*} val is the value to put in the url.
@@ -118,22 +135,5 @@ Window.Vinya.functions.updateStorage = function updateStorage() {
     tempURL.searchParams.append(Window.Vinya.URLParams.lang, Window.Vinya.url.searchParams.get(Window.Vinya.URLParams.lang));
   }
   // store the parameters and current url base
-  localStorage.setItem('videoParams', tempURL.search);
-}
-
-/**
- * Determines if it is possible to load the desired video and displays
- * the appropriate response if it is not possible.
- * @returns whether or not the desired video is in the current video list.
- */
-Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
-  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
-    Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
-    if (Window.Vinya.DOMElements.video != undefined) {
-      Window.Vinya.DOMElements.hide('video');
-    }
-    Window.Vinya.DOMElements.hide('spinner');
-    return false;
-  }
-  return true;
+  localStorage.setItem(Window.Vinya.localKey, tempURL.search);
 }

--- a/user/pages/assets/js/video.js
+++ b/user/pages/assets/js/video.js
@@ -21,8 +21,12 @@ Window.Vinya.addEventListeners = function addEventListeners() {
  */
 Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
   // display the selected video
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoTitle, Window.Vinya.DOMElements.languages.value);
-  Window.Vinya.updateURL(Window.Vinya.URLParams.lang, Window.Vinya.DOMElements.languages.value);
+  var title = Window.Vinya.DOMElements.videoList.value, lang = Window.Vinya.DOMElements.languages.value;
+  if (Window.Vinya.videoPlayerPreCheck(title)) {
+    Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
+    Window.Vinya.updateURL(Window.Vinya.URLParams.lang, lang);
+  }
+ 
 }
 
 /**
@@ -89,7 +93,9 @@ Window.Vinya.parseURL = function parseURL() {
   if (params.has(Window.Vinya.URLParams.lang)) {
     Window.Vinya.DOMElements.languages.value = lang;
   }
-  Window.Vinya.createVimeoPlayer(Window.Vinya.videoTitle, lang);
+  if (Window.Vinya.videoPlayerPreCheck(title)) {
+    Window.Vinya.createVimeoPlayer(Window.Vinya[Window.Vinya.videoTitle][lang]);
+  }
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
     Window.Vinya.player.setCurrentTime(time);

--- a/user/pages/assets/js/videos.js
+++ b/user/pages/assets/js/videos.js
@@ -2,14 +2,14 @@
 /**
  * Adds event listeners for each of the select options.
  */
-Window.Vinya.addEventListeners = function addEventListeners() {
+Window.Vinya.functions.addEventListeners = function addEventListeners() {
   Window.Vinya.DOMElements.languages.addEventListener("change", function() {
-    Window.Vinya.fixBtnDisplay(Window.Vinya.DOMElements.videoList.value);
-    Window.Vinya.changeVideo(Window.Vinya.DOMElements.videoList.value, true);
+    Window.Vinya.functions.fixBtnDisplay(Window.Vinya.DOMElements.videoList.value);
+    Window.Vinya.functions.changeVideo(Window.Vinya.DOMElements.videoList.value, true);
   });
 
   Window.Vinya.DOMElements.videoList.addEventListener("change", function () {
-    Window.Vinya.displaySelectedVideo();
+    Window.Vinya.functions.displaySelectedVideo();
   });
   Window.Vinya.DOMElements.subtitles.addEventListener("change", function() {
     if (Window.Vinya.DOMElements.subtitles.value == 'off') {
@@ -24,8 +24,9 @@ Window.Vinya.addEventListeners = function addEventListeners() {
     var epsiodeFormat = title.replace(episodeNum, '');
     var next = episodeNum + 1;
     Window.Vinya.DOMElements.videoList.value = epsiodeFormat + next;
-    Window.Vinya.fixBtnDisplay(epsiodeFormat + next);
-    Window.Vinya.changeVideo(epsiodeFormat + next, false);
+    Window.Vinya.DOMElements.videoTitle.innerText = Window.Vinya.videoList[epsiodeFormat + next].title;
+    Window.Vinya.functions.fixBtnDisplay(epsiodeFormat + next);
+    Window.Vinya.functions.changeVideo(epsiodeFormat + next, false);
   });
   Window.Vinya.DOMElements.backEpisode.addEventListener("click", function() {
     var title = Window.Vinya.DOMElements.videoList.value;
@@ -33,9 +34,9 @@ Window.Vinya.addEventListeners = function addEventListeners() {
     var epsiodeFormat = title.replace(episodeNum, '');
     var  back = episodeNum - 1;
     Window.Vinya.DOMElements.videoList.value = epsiodeFormat + back;
-    Window.Vinya.DOMElements.videoTitle.innerText = Window.Vinya[epsiodeFormat + back].title;
-    Window.Vinya.fixBtnDisplay(epsiodeFormat + back);
-    Window.Vinya.changeVideo(epsiodeFormat + back, false);
+    Window.Vinya.DOMElements.videoTitle.innerText = Window.Vinya.videoList[epsiodeFormat + back].title;
+    Window.Vinya.functions.fixBtnDisplay(epsiodeFormat + back);
+    Window.Vinya.functions.changeVideo(epsiodeFormat + back, false);
   });
 
 } 
@@ -44,22 +45,22 @@ Window.Vinya.addEventListeners = function addEventListeners() {
  * Makes sure that the buttons are currently setup correctly
  * @param {String} episode is the name of the currently selected episode.
  */
-Window.Vinya.fixBtnDisplay = function fixBtnDisplay(episode) {
+Window.Vinya.functions.fixBtnDisplay = function fixBtnDisplay(episode) {
   var lang = Window.Vinya.DOMElements.languages.value;
-  if (Window.Vinya[episode][lang]) {
+  if (Window.Vinya.videoList[episode][lang]) {
     // fix the title
-    Window.Vinya.DOMElements.videoTitle.innerText = Window.Vinya[episode].title;
+    Window.Vinya.DOMElements.videoTitle.innerText = Window.Vinya.videoList[episode].title;
     // extract a number from the current episode name
     var episodeNum = parseInt(episode.replace( /^\D+/g, ''));
     var epsiodeFormat = episode.replace(episodeNum, '');
     var next = episodeNum + 1, back = episodeNum - 1;
     // hide or display the back and forward buttons
-    if (Window.Vinya[epsiodeFormat + next] != undefined && Window.Vinya[epsiodeFormat + next][lang] != undefined ) {
+    if (Window.Vinya.videoList[epsiodeFormat + next] != undefined && Window.Vinya.videoList[epsiodeFormat + next][lang] != undefined ) {
       Window.Vinya.DOMElements.display('nextEpisode');
     } else {
       Window.Vinya.DOMElements.hide('nextEpisode');
     }
-    if (Window.Vinya[epsiodeFormat + back] != undefined && Window.Vinya[epsiodeFormat + back][lang] != undefined) {
+    if (Window.Vinya.videoList[epsiodeFormat + back] != undefined && Window.Vinya.videoList[epsiodeFormat + back][lang] != undefined) {
       Window.Vinya.DOMElements.display('backEpisode');
     } else {
       Window.Vinya.DOMElements.hide('backEpisode');
@@ -75,18 +76,18 @@ Window.Vinya.fixBtnDisplay = function fixBtnDisplay(episode) {
 /**
  * Displays the video selected by the user.
  */
-Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
+Window.Vinya.functions.displaySelectedVideo = function displaySelectedVideo() {
   var title = Window.Vinya.DOMElements.videoList.value, lang = Window.Vinya.DOMElements.languages.value;
-  Window.Vinya.fixBtnDisplay(title);
+  Window.Vinya.functions.fixBtnDisplay(title);
   // display the selected video
   if (Window.Vinya.player === undefined ) {
-    if (Window.Vinya.videoPlayerPreCheck(title)) {
-      Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
-      Window.Vinya.updateURL(Window.Vinya.URLParams.title, title);
-      Window.Vinya.updateURL(Window.Vinya.URLParams.lang, lang);
+    if (Window.Vinya.functions.videoPlayerPreCheck(title)) {
+      Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoList[title][lang]);
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.title, title);
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.lang, lang);
     }
   } else {
-    Window.Vinya.changeVideo(title, false);
+    Window.Vinya.functions.changeVideo(title, false);
   }
 }
 
@@ -96,13 +97,13 @@ Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
  * @param {String} videoName is the name of the video to display.
  * @param {Boolean} languageChanged is whether or not the language was changed.
  */
-Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
-  if (Window.Vinya.videoPlayerPreCheck(videoName)) {
+Window.Vinya.functions.changeVideo = function changeVideo(videoName, languageChanged) {
+  if (Window.Vinya.functions.videoPlayerPreCheck(videoName)) {
     Window.Vinya.DOMElements.videoError.innerText = ""; 
-    Window.Vinya.updateURL(Window.Vinya.URLParams.lang, Window.Vinya.DOMElements.languages.value);
+    Window.Vinya.functions.updateURL(Window.Vinya.URLParams.lang, Window.Vinya.DOMElements.languages.value);
     Window.Vinya.DOMElements.display('spinner');
     Window.Vinya.player.unload().then(function () {
-      Window.Vinya.videoOptions.id = Window.Vinya[videoName][Window.Vinya.DOMElements.languages.value];
+      Window.Vinya.videoOptions.id = Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value];
       Window.Vinya.player.loadVideo(Window.Vinya.videoOptions).then( function () {
         Window.Vinya.player.ready().then(function(){
           if (languageChanged && Window.Vinya.url.searchParams.has(Window.Vinya.URLParams.time)) {
@@ -115,7 +116,7 @@ Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
       });
     });
     if (!languageChanged) {
-      Window.Vinya.updateURL(Window.Vinya.URLParams.title, videoName);
+      Window.Vinya.functions.updateURL(Window.Vinya.URLParams.title, videoName);
     }
   }
 }
@@ -125,7 +126,7 @@ Window.Vinya.changeVideo = function changeVideo(videoName, languageChanged) {
  * @param {String} param is the param that will added or updated with the val;
  * @param {*} val is the value to put in the url.
  */
-Window.Vinya.updateURL = function updateURL(param, val) {
+Window.Vinya.functions.updateURL = function updateURL(param, val) {
   // when the video is changed, the time should be reset
   if (param === Window.Vinya.URLParams.title) {
     Window.Vinya.url.searchParams.delete(Window.Vinya.URLParams.time);
@@ -143,14 +144,14 @@ Window.Vinya.updateURL = function updateURL(param, val) {
   if (history.pushState) {
     window.history.pushState({path:Window.Vinya.url.href},'',Window.Vinya.url.href);
   }
-  Window.Vinya.updateStorage();
+  Window.Vinya.functions.updateStorage();
 }
 
 /**
  * Determines which if any of the videos are in the URL and displays
  * content appropriately.
  */
-Window.Vinya.parseURL = function parseURL() {
+Window.Vinya.functions.parseURL = function parseURL() {
   var params = Window.Vinya.url.searchParams;
   var title = params.get(Window.Vinya.URLParams.title), lang = params.get(Window.Vinya.URLParams.lang), time = params.get(Window.Vinya.URLParams.time),
     sub = params.get(Window.Vinya.URLParams.sub);
@@ -168,9 +169,9 @@ Window.Vinya.parseURL = function parseURL() {
     Window.Vinya.DOMElements.languages.value = lang;
     title = Window.Vinya.DOMElements.videoList.value;
   }
-  Window.Vinya.fixBtnDisplay(title);
-  if (Window.Vinya.videoPlayerPreCheck(title)) {
-    Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
+  Window.Vinya.functions.fixBtnDisplay(title);
+  if (Window.Vinya.functions.videoPlayerPreCheck(title)) {
+    Window.Vinya.functions.createVimeoPlayer(Window.Vinya.videoList[title][lang]);
   }
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
@@ -184,7 +185,7 @@ Window.Vinya.parseURL = function parseURL() {
 /**
  * Updates the url parameters in storage by removing all unnecesary url params. 
  */
-Window.Vinya.updateStorage = function updateStorage() {
+Window.Vinya.functions.updateStorage = function updateStorage() {
   // a list of parameters to store in local storage
   var tempURL = new URL(Window.Vinya.url.href.substring(0, Window.Vinya.url.href.indexOf('?')));
   if (Window.Vinya.url.searchParams.has(Window.Vinya.URLParams.sub)) {
@@ -205,8 +206,8 @@ Window.Vinya.updateStorage = function updateStorage() {
  * the appropriate response if it is not possible.
  * @returns whether or not the desired video is in the current video list.
  */
-Window.Vinya.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
-  if (Window.Vinya[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
+Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
+  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
     Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
     if (Window.Vinya.DOMElements.video != undefined) {
       Window.Vinya.DOMElements.hide('video');

--- a/user/pages/assets/js/videos.js
+++ b/user/pages/assets/js/videos.js
@@ -212,3 +212,32 @@ Window.Vinya.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
   }
   return true;
 }
+
+/**
+ * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
+ * @param {String} videoName is the name of the video to select.
+ * @param {String} videoLanguage is the language to get the video in.
+ */
+Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoName, videoLanguage) {
+  if (Window.Vinya.videoPlayerPreCheck(videoName)) {
+    // create iframe
+    Window.Vinya.videoOptions.id = Window.Vinya[videoName][videoLanguage];
+    Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
+    Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
+    Window.Vinya.player.on("texttrackchange", function (lang) {
+      if (!lang.language) {
+        // remove the sub from the url
+        Window.Vinya.DOMElements.subtitles.value = 'off';
+        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
+      } else {
+        Window.Vinya.DOMElements.subtitles.value = lang.language;
+        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
+      }
+    });
+    Window.Vinya.player.on("loaded", function () {
+      Window.Vinya.DOMElements.video = document.querySelector('iframe');
+      Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
+      Window.Vinya.getTextTracks();         
+    });
+  }
+}

--- a/user/pages/assets/js/videos.js
+++ b/user/pages/assets/js/videos.js
@@ -122,6 +122,23 @@ Window.Vinya.functions.changeVideo = function changeVideo(videoName, languageCha
 }
 
 /**
+ * Determines if it is possible to load the desired video and displays
+ * the appropriate response if it is not possible.
+ * @returns whether or not the desired video is in the current video list.
+ */
+Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
+  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
+    Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
+    if (Window.Vinya.DOMElements.video != undefined) {
+      Window.Vinya.DOMElements.hide('video');
+    }
+    Window.Vinya.DOMElements.hide('spinner');
+    return false;
+  }
+  return true;
+}
+
+/**
  * Takes a param name and a value and stores that value as the value of the url param.
  * @param {String} param is the param that will added or updated with the val;
  * @param {*} val is the value to put in the url.
@@ -198,22 +215,5 @@ Window.Vinya.functions.updateStorage = function updateStorage() {
     tempURL.searchParams.append(Window.Vinya.URLParams.title, Window.Vinya.url.searchParams.get(Window.Vinya.URLParams.title));
   }
   // store the parameters and current url base
-  localStorage.setItem('params', tempURL.search);
-}
-
-/**
- * Determines if it is possible to load the desired video and displays
- * the appropriate response if it is not possible.
- * @returns whether or not the desired video is in the current video list.
- */
-Window.Vinya.functions.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
-  if (Window.Vinya.videoList[videoName][Window.Vinya.DOMElements.languages.value] === undefined) {
-    Window.Vinya.DOMElements.videoError.innerText = Window.Vinya.errorMsg;
-    if (Window.Vinya.DOMElements.video != undefined) {
-      Window.Vinya.DOMElements.hide('video');
-    }
-    Window.Vinya.DOMElements.hide('spinner');
-    return false;
-  }
-  return true;
+  localStorage.setItem(Window.Vinya.localKey, tempURL.search);
 }

--- a/user/pages/assets/js/videos.js
+++ b/user/pages/assets/js/videos.js
@@ -80,9 +80,11 @@ Window.Vinya.displaySelectedVideo = function displaySelectedVideo() {
   Window.Vinya.fixBtnDisplay(title);
   // display the selected video
   if (Window.Vinya.player === undefined ) {
-    Window.Vinya.createVimeoPlayer(title, lang);
-    Window.Vinya.updateURL(Window.Vinya.URLParams.title, title);
-    Window.Vinya.updateURL(Window.Vinya.URLParams.lang, lang);
+    if (Window.Vinya.videoPlayerPreCheck(title)) {
+      Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
+      Window.Vinya.updateURL(Window.Vinya.URLParams.title, title);
+      Window.Vinya.updateURL(Window.Vinya.URLParams.lang, lang);
+    }
   } else {
     Window.Vinya.changeVideo(title, false);
   }
@@ -167,7 +169,9 @@ Window.Vinya.parseURL = function parseURL() {
     title = Window.Vinya.DOMElements.videoList.value;
   }
   Window.Vinya.fixBtnDisplay(title);
-  Window.Vinya.createVimeoPlayer(title, lang);
+  if (Window.Vinya.videoPlayerPreCheck(title)) {
+    Window.Vinya.createVimeoPlayer(Window.Vinya[title][lang]);
+  }
   // check to see if the time is in the url, if so the video will be set to that time
   if (params.has(Window.Vinya.URLParams.time)) {
     Window.Vinya.player.setCurrentTime(time);
@@ -211,33 +215,4 @@ Window.Vinya.videoPlayerPreCheck = function videoPlayerPreCheck(videoName) {
     return false;
   }
   return true;
-}
-
-/**
- * Creates an iframe using the video name and language to select the appropriate link for the Window.Vinya.DOMElements.video.
- * @param {String} videoName is the name of the video to select.
- * @param {String} videoLanguage is the language to get the video in.
- */
-Window.Vinya.createVimeoPlayer = function createVimeoPlayer(videoName, videoLanguage) {
-  if (Window.Vinya.videoPlayerPreCheck(videoName)) {
-    // create iframe
-    Window.Vinya.videoOptions.id = Window.Vinya[videoName][videoLanguage];
-    Window.Vinya.player = new Vimeo.Player('videosFrames', Window.Vinya.videoOptions);
-    Window.Vinya.player.on("timeupdate", Window.Vinya.updateURLTime); // updates the url time when progress is made in the video
-    Window.Vinya.player.on("texttrackchange", function (lang) {
-      if (!lang.language) {
-        // remove the sub from the url
-        Window.Vinya.DOMElements.subtitles.value = 'off';
-        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, 'off');
-      } else {
-        Window.Vinya.DOMElements.subtitles.value = lang.language;
-        Window.Vinya.updateURL(Window.Vinya.URLParams.sub, lang.language);
-      }
-    });
-    Window.Vinya.player.on("loaded", function () {
-      Window.Vinya.DOMElements.video = document.querySelector('iframe');
-      Window.Vinya.DOMElements.video.setAttribute('class' , 'resp-iframe');
-      Window.Vinya.getTextTracks();         
-    });
-  }
 }

--- a/user/themes/quark/templates/subtitles.html.twig
+++ b/user/themes/quark/templates/subtitles.html.twig
@@ -17,12 +17,14 @@
 <script>
   Window.Vinya = {
     defLang: '{{~grav.language.getActive~}}',
-    videoID: '{{ page.header.videoID }}'
-    };
-  Object.assign(Window.Vinya, {'errorMsg': '{{ error }}'});
-  Window.Vinya.URLParams = { 
-    time: "time",
-    sub: "sub"
+    videoID: '{{ page.header.videoID }}',
+    errorMsg: '{{ error }}',
+    videoList: {},
+    functions: {},
+    URLParams: { 
+      time: "time",
+      sub: "sub"
+    }
   };
   // this function runs itself
   (function(){

--- a/user/themes/quark/templates/subtitles.html.twig
+++ b/user/themes/quark/templates/subtitles.html.twig
@@ -17,16 +17,9 @@
 <script>
   Window.Vinya = {
     defLang: '{{~grav.language.getActive~}}',
-    videoLanguage: '{{ page.header.videoLanguage }}',
-    videoTitle: '{{ page.header.videoTitle }}'
+    videoID: '{{ page.header.videoID }}'
     };
   Object.assign(Window.Vinya, {'errorMsg': '{{ error }}'});
-  {% for video in config.video.videos %}
-    Object.assign(Window.Vinya, {'{{ video.name }}': {} })
-    {% for id in video.ids %}
-      Object.assign(Window.Vinya['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});
-    {% endfor %}
-  {% endfor %}
   Window.Vinya.URLParams = { 
     time: "time",
     sub: "sub"

--- a/user/themes/quark/templates/subtitles.html.twig
+++ b/user/themes/quark/templates/subtitles.html.twig
@@ -19,7 +19,7 @@
     defLang: '{{~grav.language.getActive~}}',
     videoID: '{{ page.header.videoID }}',
     errorMsg: '{{ error }}',
-    videoList: {},
+    localKey: '{{ page.header.pageIdentifier }}',
     functions: {},
     URLParams: { 
       time: "time",
@@ -28,7 +28,7 @@
   };
   // this function runs itself
   (function(){
-    var lastParams = localStorage.getItem('subParams');
+    var lastParams = localStorage.getItem(Window.Vinya.localKey);
     // add the appropriate params to the website if they exist
     if (lastParams != undefined && window.location.search === '' && !window.location.href.includes(lastParams)) {
      window.location.search = lastParams;

--- a/user/themes/quark/templates/video.html.twig
+++ b/user/themes/quark/templates/video.html.twig
@@ -16,6 +16,7 @@
     defLang: '{{~grav.language.getActive~}}',
     videoTitle: '{{ page.header.videoTitle }}',
     errorMsg: '{{ error }}',
+    localKey: '{{ page.header.pageIdentifier }}',
     videoList: {},
     functions: {},
     URLParams: {
@@ -32,7 +33,7 @@
   {% endfor %}
   // this function runs itself
   (function(){
-    var lastParams = localStorage.getItem('videoParams');
+    var lastParams = localStorage.getItem(Window.Vinya.localKey);
     // add the appropriate params to the website if they exist
     if (lastParams != undefined && window.location.search === '' && !window.location.href.includes(lastParams)) {
      window.location.search = lastParams;

--- a/user/themes/quark/templates/video.html.twig
+++ b/user/themes/quark/templates/video.html.twig
@@ -17,7 +17,7 @@
     videoTitle: '{{ page.header.videoTitle }}'
   };
   Object.assign(Window.Vinya, {'errorMsg': '{{ error }}'});
-  {% for video in config.video.videos %}
+  {% for video in videos %}
     Object.assign(Window.Vinya, {'{{ video.name }}': {} })
     {% for id in video.ids %}
       Object.assign(Window.Vinya['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});

--- a/user/themes/quark/templates/video.html.twig
+++ b/user/themes/quark/templates/video.html.twig
@@ -14,20 +14,22 @@
 <script>
   Window.Vinya = {
     defLang: '{{~grav.language.getActive~}}',
-    videoTitle: '{{ page.header.videoTitle }}'
+    videoTitle: '{{ page.header.videoTitle }}',
+    errorMsg: '{{ error }}',
+    videoList: {},
+    functions: {},
+    URLParams: {
+      lang: "lang",  
+      time: "time",
+      sub: "sub"
+    }
   };
-  Object.assign(Window.Vinya, {'errorMsg': '{{ error }}'});
   {% for video in videos %}
-    Object.assign(Window.Vinya, {'{{ video.name }}': {} })
+    Object.assign(Window.Vinya.videoList, {'{{ video.name }}': {} })
     {% for id in video.ids %}
-      Object.assign(Window.Vinya['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});
+      Object.assign(Window.Vinya.videoList['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});
     {% endfor %}
   {% endfor %}
-  Window.Vinya.URLParams = {
-    lang: "lang", 
-    time: "time",
-    sub: "sub"
-  };
   // this function runs itself
   (function(){
     var lastParams = localStorage.getItem('videoParams');

--- a/user/themes/quark/templates/videos.html.twig
+++ b/user/themes/quark/templates/videos.html.twig
@@ -73,21 +73,25 @@
 
 {% block inlineScript %}
 <script>
-  Window.Vinya = {defLang: '{{~grav.language.getActive~}}'};
-  Object.assign(Window.Vinya, {'errorMsg': '{{ error }}' });
+  Window.Vinya = {
+    defLang: '{{~grav.language.getActive~}}',
+    errorMsg: '{{ error }}',
+    videoList: {},
+    functions: {},
+    URLParams: {
+      lang: "lang", 
+      title: "video", 
+      time: "time",
+      sub: "sub"
+    }
+  };
   {% for video in videos %}
-    Object.assign(Window.Vinya, {'{{ video.name }}': {} });
-    Object.assign(Window.Vinya['{{ video.name }}'], { title: '{{ attribute(video.title, grav.language.getActive) }}' });
+    Object.assign(Window.Vinya.videoList, {'{{ video.name }}': {} });
+    Object.assign(Window.Vinya.videoList['{{ video.name }}'], { title: '{{ attribute(video.title, grav.language.getActive) }}' });
     {% for id in video.ids %}
-      Object.assign(Window.Vinya['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});
+      Object.assign(Window.Vinya.videoList['{{ video.name }}'], { {{ id.language }}: {{ id.id }}});
     {% endfor %}
   {% endfor %}
-  Window.Vinya.URLParams = {
-    lang: "lang", 
-    title: "video", 
-    time: "time",
-    sub: "sub"
-  };
   // this function runs itself
   (function(){
     var lastParams = localStorage.getItem('params');

--- a/user/themes/quark/templates/videos.html.twig
+++ b/user/themes/quark/templates/videos.html.twig
@@ -3,6 +3,10 @@
 {% set select = attribute(config.video.select, grav.language.getActive) %}
 {% set error = attribute(config.video.error, grav.language.getActive) %}
 {% set languages = attribute(config.video.languages, grav.language.getActive) %}
+{% if page.header.videoList is defined %}
+  {% set videos = attribute(config.video, page.header.videoList) %}
+{% endif %}
+
 
 {% block content %} 
 {% do assets.addCss('page://assets/css/videos.css') %}
@@ -23,7 +27,7 @@
         <p>{{ select.videos }}</p>
         <div class="select">
           <select id="videos">
-            {% for video in config.video.videos %}
+            {% for video in videos %}
               <option value="{{ video.name }}">{{ video.name }}</option>
             {% endfor %}
           </select>
@@ -71,7 +75,7 @@
 <script>
   Window.Vinya = {defLang: '{{~grav.language.getActive~}}'};
   Object.assign(Window.Vinya, {'errorMsg': '{{ error }}' });
-  {% for video in config.video.videos %}
+  {% for video in videos %}
     Object.assign(Window.Vinya, {'{{ video.name }}': {} });
     Object.assign(Window.Vinya['{{ video.name }}'], { title: '{{ attribute(video.title, grav.language.getActive) }}' });
     {% for id in video.ids %}

--- a/user/themes/quark/templates/videos.html.twig
+++ b/user/themes/quark/templates/videos.html.twig
@@ -7,7 +7,6 @@
   {% set videos = attribute(config.video, page.header.videoList) %}
 {% endif %}
 
-
 {% block content %} 
 {% do assets.addCss('page://assets/css/videos.css') %}
 <div id="swapLanguage">
@@ -76,6 +75,7 @@
   Window.Vinya = {
     defLang: '{{~grav.language.getActive~}}',
     errorMsg: '{{ error }}',
+    localKey: '{{ page.header.pageIdentifier }}',
     videoList: {},
     functions: {},
     URLParams: {
@@ -94,7 +94,7 @@
   {% endfor %}
   // this function runs itself
   (function(){
-    var lastParams = localStorage.getItem('params');
+    var lastParams = localStorage.getItem(Window.Vinya.localKey);
     // add the appropriate params to the website if they exist
     if (lastParams != undefined && window.location.search === '' && !window.location.href.includes(lastParams)) {
      window.location.search = lastParams;


### PR DESCRIPTION
Updates the JavaScript by better organizing the functions and making the organization easier to follow (fixes #4 ).

Updates the templates to allow for multiple video lists by allowing the developer to specify the video list to be used for a specific page (fixes #3 ).

Updates the subtitles template to use a Vimeo ID instead of requiring the use of a video list and several other options (fixes #5 ).

Updates the templates to make them look more appealing (fixes #6 ).

Updates the templates to use a page identifier in order to store url params for each different page. This means that a developer can have multiple of the same template in use and not have issues where the stored data about what the user last did on a page using a specific template gets pulled over and used even though the two pages are different (fixes #7 ).

Updates the README and JavaScript to follow the changes made to the templates.